### PR TITLE
Default Values for DpdShipmentResponseException

### DIFF
--- a/src/Exceptions/DpdShipmentResponseException.php
+++ b/src/Exceptions/DpdShipmentResponseException.php
@@ -8,8 +8,8 @@ class DpdShipmentResponseException extends \Exception
 {
     public function __construct(
         string $message,
-        public ?array $shipmentData,
-        public ?\StdClass $orderResult,
+        public ?array $shipmentData = null,
+        public ?\StdClass $orderResult = null,
         int $code = 0,
         ?Throwable $previous = null
     )


### PR DESCRIPTION
## Description
In class DpdShipmentResponseException shipmentData and orderResult are nullable.
But in the DpdShipmentService it does not do anything with those parameters. Now by default the value will be null.

## Changes
- added default value null to nullable arguments because by default you want it to be null